### PR TITLE
HOTFIX: Filtering Vera Scenes to Google Assistant. 

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -105,6 +105,7 @@ hue: !include includes/philips_hue.yaml
 # Group Merge Directory
 
 group: !include_dir_merge_named group/
+scene: !include_dir_merge_named scenes/
 
 
 # -----

--- a/includes/customize.yaml
+++ b/includes/customize.yaml
@@ -16,8 +16,8 @@ light.play_room_3:
   google_assistant: true
   #google_assistant_name: play room
   google_assistant_type: light
-  aliases:
-    - game room
+#  aliases:
+#    - game room
 
 light.mail_table_4:
   icon: mdi:email
@@ -42,8 +42,8 @@ light.living_room_tree_7:
   friendly_name: Living Room Tree
   google_assistant: true
   google_assistant_type: light
-  aliases:
-    - tree
+#  aliases:
+#    - tree
 
 light.outside_side_8:
   friendly_name: Front Side
@@ -72,8 +72,8 @@ light.chandelier_12:
   google_assistant: true
   google_assistant_type: light
 #  google_assistant_name: chandelier
-  aliases:
-    - chandelier
+#  aliases:
+#    - chandelier
 
 light.mobile_2_14:
   icon: mdi:pine-tree
@@ -87,6 +87,35 @@ light.mobile_1_33:
   google_assistant: true
   google_assistant_type: light
 
+############################################################
+#
+# Vera Scenes
+#
+############################################################
+#DO NOT WANT TO EXPOSE VERA'S SCENES TO GOOGLE ASSISTANT TO
+#AVOID CONFUSION WITH HA'S SCENES
+
+scene.going_to_bed:
+  google_assistant: false
+
+scene.holidaylights_off:
+  google_assistant: false
+
+scene.holidaylights_on:
+  google_assistant: false
+
+scene.insidelights_off:
+  google_assistant: false
+
+scene.insidelights_on:
+  google_assistant: false
+
+scene.outsidelights_off:
+  google_assistant: false
+
+scene.outsidelights_on:
+  google_assistant: false
+
 
 ############################################################
 #
@@ -99,8 +128,8 @@ light.living_room_lamp:
   icon: mdi:lamp
   google_assistant: true
   google_assistant_type: light
-  aliases:
-    - lamp
+#  aliases:
+#    - lamp
 
 ############################################################
 #

--- a/includes/google_assistant.yaml
+++ b/includes/google_assistant.yaml
@@ -14,4 +14,5 @@ exposed_domains:
   - light
   - scene
   - climate
+  - media_player
 #  - group

--- a/scenes/test.yaml
+++ b/scenes/test.yaml
@@ -1,0 +1,22 @@
+###########################################################
+#
+# Home Assistant Scene: Nighttime Lights
+#
+############################################################
+
+- name: Evening Lights
+  entities:
+    group.lights_inside:  on
+    group.lights_outside: off
+    group.lights_other:   off
+
+- name: Nighttime Lights On
+  entities:
+    group.lights_inside:  on
+    group.lights_outside: on
+    group.lights_other:   off
+#    light.living_room_lamp:
+#      state: on
+#      color_temp: 153
+#      xy_color: 0.6603,0.3219
+#      brightness: 79


### PR DESCRIPTION
With last master pull into production Pi, it was noticed that the Living Room Tree was not powering off via Google Assistant. 

After investigation, it was realized that Home Assistant was forwarding only the aliases name in the includes/customize.yaml 

A HOTFIX was deployed to comment out the aliases, and disable the scenes defined within Vera to forward to Google Assistant. 